### PR TITLE
 Speed improvements for focusMetro()

### DIFF
--- a/county-level.js
+++ b/county-level.js
@@ -190,7 +190,7 @@ function createMap() {
         widthAdjust: -300,
         align: "left",
         x: 300,
-        y: -50, //may have to change this, depending on length of notes
+        y: -50, //may have to change this, depending on lenght of notes
         verticalAlign: "bottom",
         style: {
           color: "#999999",
@@ -397,8 +397,11 @@ function focusMetro(GEOID, name) {
     })
 
   } else {
-
-    map.series[0].setData([])
+    var null_data = []
+    map_data.forEach(function (el, idx) {
+      null_data.push([el.fips, null])
+    })
+    map.series[0].setData(null_data)
     map.renderer.label('There are no data for this county',270,270,'callout',10,10)
       .css({
       color: '#FFFFFF'
@@ -421,21 +424,13 @@ function focusMetro(GEOID, name) {
     }, 1300)
   }
 
-
-  //re-select selected county
-  map.series[0].data.forEach(function(pt) {
-    if (pt.options.fips == GEOID) {
-      map.series[0].data[pt.index].select()
-    }
-  })
-
   //add button to clear the selection
   if (!$('#clear_button').length) {
     map.renderer.button('Clear selection',450,450)
       .attr({
       padding: 7,
       id: 'clear_button'
-    })
+      })
       .add()
 
     $('#clear_button').click(function () { 


### PR DESCRIPTION
Highcharts is more efficient at updating the map when you pass a data object that is the same length as the current data (I saw this in their documentation). Before, when we selected a specific metro, we passed a new data object that was the length of the number of origin or destination counties that had flow data for the selected county. Now, the code iterates over the base `map_data` data for all counties, and passes either data or `null` to the new data object. (Also, I changed the data that we pass to the map from an array to an object because in testing it was faster that way.)

This is 50-75% faster than the old way, and I think it makes for a much smoother user experience.

Also, since we aren't changing the indexes of the county data, we don't need to re-select the correct county when we change data.